### PR TITLE
Workaround

### DIFF
--- a/src/button/Button.test.tsx
+++ b/src/button/Button.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { ThemeProvider } from '@mui/material';
+import { ThemeProvider } from '@emotion/react';
 
 import { lightTheme } from '../themes/light.theme';
 import Button from './Button';
@@ -10,6 +10,8 @@ describe('<Button />', () => {
 
     it('should render correctly with dark theme', () => {
         const toggleThemeMock = () => {};
+
+        const x = lightTheme;
 
         const view = render(
             <ThemeProvider theme={lightTheme}>

--- a/src/button/__snapshots__/Button.test.tsx.snap
+++ b/src/button/__snapshots__/Button.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`<Button /> > should render correctly with dark theme 1`] = `
 <body>
   <div>
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium eja6qb0 css-1eznx67-MuiButtonBase-root-MuiButton-root-StyledButton"
+      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-1dlc1jm-StyledButton eja6qb0 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
       tabindex="0"
       type="button"
     >
@@ -23,7 +23,7 @@ exports[`<Button /> > should render correctly with light theme 1`] = `
 <body>
   <div>
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium eja6qb0 css-1eznx67-MuiButtonBase-root-MuiButton-root-StyledButton"
+      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-1dlc1jm-StyledButton eja6qb0 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
       tabindex="0"
       type="button"
     >


### PR DESCRIPTION
To fix the issue in tests, instead of importing `ThemeProvider` from `@mui/material`, I use `@emotion/react` in the tests and the missing properties appear again.

I am not exactly sure about the implications of this, but being able to upgrade Vite to a more recent version is more valuable in my case than rendering the components exactly like the app code does. 👍 
